### PR TITLE
Bump Terraform version in `README.md` usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ jobs:
       - name: Terraform format check
         uses: flipgroup/action-terraform-fmt-check@main
         with:
-          version: 1.0.0
+          version: 1.1.5
 ```


### PR DESCRIPTION
Moving along the workflow usage example to latest stable Terraform: https://github.com/hashicorp/terraform/releases/tag/v1.1.5