### PR TITLE
GitHub actions bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Terraform format check
         uses: flipgroup/action-terraform-fmt-check@main
         with:
-          version: 1.3.6
+          version: 1.5.7
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: ${{ inputs.version }}
         terraform_wrapper: false


### PR DESCRIPTION
Bumping GitHub Action versions to those supporting Node.js v20 - [since v16 is now deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).
