### PR TITLE
GitHub Actions bump Node.js `v24` releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v6
       - name: Terraform format check
         uses: flipgroup/action-terraform-fmt-check@main
         with:

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # @v4.0.1
       with:
         terraform_version: ${{ inputs.version }}
         terraform_wrapper: false


### PR DESCRIPTION
Applies the following GitHub Action workflow changes:

- Implement the use of GitHub Actions compatible with Node.js `v24`.
- Swap out the use of version tags for external actions to full SHA-1 commits to defeat action tainting / supply chain attacks.
